### PR TITLE
fixed the Makefile in demo && fixed the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We provided a fully working example.
 ```bash
 git clone https://github.com/serpapi/google_search_results_java.git
 cd google_search_results_java/demo
-make run api_key=<your private key>
+make all API_KEY=<your private key>
 ```
 Note: You need an account with SerpApi to obtain this key from: https://serpapi.com/dashboard
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -18,6 +18,7 @@ clean:
 dep:
 	$(MAKE) -C ../ build
 	rm -rf libs/*.jar
+	mkdir -p libs
 	cp ../build/libs/* libs
 
 build: clean


### PR DESCRIPTION
Hi maintainers,

There was a bug in the Makefile under demo directory. I was able to fix it and also updated the commands in the readme file for quick installation. Following were the errors I was getting before the fix. It was failing at make run command. Since there was only one file to be copied, it was copying it as a file called "lib" rather than copying a file under the newly created "lib" directory. The quick installation commands are also updated in the Makefile under demo directory so you should be able to execute it properly.

![Screenshot from 2020-09-18 16-14-51](https://user-images.githubusercontent.com/6724613/93652509-218fbe80-f9ca-11ea-99a7-4b9be5e1c061.png)

![Screenshot from 2020-09-18 16-16-36](https://user-images.githubusercontent.com/6724613/93652580-59970180-f9ca-11ea-9303-5c5593f949bf.png)

It runs successfully post fix as in the following screenshot.

![Screenshot from 2020-09-18 16-17-56](https://user-images.githubusercontent.com/6724613/93652640-9a8f1600-f9ca-11ea-8956-47b182d003bd.png)

Please review and accept my pull request.

Thank you.
